### PR TITLE
[feat] sleep 탭 전환 효과 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@nivo/core": "^0.99.0",
+        "@nivo/pie": "^0.99.0",
         "@supabase/supabase-js": "^2.53.0",
         "dayjs": "^1.11.13",
         "framer-motion": "^12.23.12",
@@ -2848,6 +2850,150 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/@nivo/arcs": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/arcs/-/arcs-0.99.0.tgz",
+      "integrity": "sha512-UcvWLQPl+A3APk2Gm74N5xDfT+ATnVs2XkP73WxhYPWJk+dBzF00cndA5g/dptOwdFBvvo62VgcCsNiwUsjKTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/core": "9.4.5 || ^9.7.2 || ^10.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-shape": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/colors": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.99.0.tgz",
+      "integrity": "sha512-hyYt4lEFIfXOUmQ6k3HXm3KwhcgoJpocmoGzLUqzk7DzuhQYJo+4d5jIGGU0N/a70+9XbHIdpKNSblHAIASD3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@types/d3-color": "^3.0.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-scale-chromatic": "^3.0.0",
+        "d3-color": "^3.1.0",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/core": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.99.0.tgz",
+      "integrity": "sha512-olCItqhPG3xHL5ei+vg52aB6o+6S+xR2idpkd9RormTTUniZb8U2rOdcQojOojPY5i9kVeQyLFBpV4YfM7OZ9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "react-virtualized-auto-sizer": "^1.0.26",
+        "use-debounce": "^10.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/legends": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.99.0.tgz",
+      "integrity": "sha512-P16FjFqNceuTTZphINAh5p0RF0opu3cCKoWppe2aRD9IuVkvRm/wS5K1YwMCxDzKyKh5v0AuTlu9K6o3/hk8hA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/text": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@types/d3-scale": "^4.0.8",
+        "d3-scale": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/pie": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/pie/-/pie-0.99.0.tgz",
+      "integrity": "sha512-zUbo8UdLndp2RMljrOqitAKKEnl7YypkJrOzjKLk8jQGU7qqUKtgFoJIPhiBsvNPs3xtX2KwgtS1+JKNTNns7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/arcs": "0.99.0",
+        "@nivo/colors": "0.99.0",
+        "@nivo/core": "0.99.0",
+        "@nivo/legends": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@nivo/tooltip": "0.99.0",
+        "@types/d3-shape": "^3.1.6",
+        "d3-shape": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/text": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/text/-/text-0.99.0.tgz",
+      "integrity": "sha512-ho3oZpAZApsJNjsIL5WJSAdg/wjzTBcwo1KiHBlRGUmD+yUWO8qp7V+mnYRhJchwygtRVALlPgZ/rlcW2Xr/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/theming": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/theming/-/theming-0.99.0.tgz",
+      "integrity": "sha512-KvXlf0nqBzh/g2hAIV9bzscYvpq1uuO3TnFN3RDXGI72CrbbZFTGzprPju3sy/myVsauv+Bb+V4f5TZ0jkYKRg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
+    "node_modules/@nivo/tooltip": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.99.0.tgz",
+      "integrity": "sha512-weoEGR3xAetV4k2P6k96cdamGzKQ5F2Pq+uyDaHr1P3HYArM879Pl+x+TkU0aWjP6wgUZPx/GOBiV1Hb1JxIqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nivo/core": "0.99.0",
+        "@nivo/theming": "0.99.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2 || ^10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17.0 || ^18.0 || ^19.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "license": "MIT",
@@ -2999,6 +3145,78 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-10.0.1.tgz",
+      "integrity": "sha512-BGL3hA66Y8Qm3KmRZUlfG/mFbDPYajgil2/jOP0VXf2+o2WPVmcDps/eEgdDqgf5Pv9eBbyj7LschLMuSjlW3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~10.0.1",
+        "@react-spring/types": "~10.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-10.0.1.tgz",
+      "integrity": "sha512-KaMMsN1qHuVTsFpg/5ajAVye7OEqhYbCq0g4aKM9bnSZlDBBYpO7Uf+9eixyXN8YEbF+YXaYj9eoWDs+npZ+sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.1",
+        "@react-spring/shared": "~10.0.1",
+        "@react-spring/types": "~10.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-10.0.1.tgz",
+      "integrity": "sha512-UrzG/d6Is+9i0aCAjsjWRqIlFFiC4lFqFHrH63zK935z2YDU95TOFio4VKGISJ5SG0xq4ULy7c1V3KU+XvL+Yg==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-10.0.1.tgz",
+      "integrity": "sha512-KR2tmjDShPruI/GGPfAZOOLvDgkhFseabjvxzZFFggJMPkyICLjO0J6mCIoGtdJSuHywZyc4Mmlgi+C88lS00g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~10.0.1",
+        "@react-spring/types": "~10.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-10.0.1.tgz",
+      "integrity": "sha512-Fk1wYVAKL+ZTYK+4YFDpHf3Slsy59pfFFvnnTfRjQQFGlyIo4VejPtDs3CbDiuBjM135YztRyZjIH2VbycB+ZQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/web": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.0.1.tgz",
+      "integrity": "sha512-FgQk02OqFrYyJBTTnBTWAU0WPzkHkKXauc6aeexcvATvLapUxwnfGuLlsLYF8BYjEVfkivPT04ziAue6zyRBtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.1",
+        "@react-spring/core": "~10.0.1",
+        "@react-spring/shared": "~10.0.1",
+        "@react-spring/types": "~10.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -3436,6 +3654,48 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -5676,6 +5936,140 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/d3-time-format/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-time-format/node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/d3-time-format/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -8270,6 +8664,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -12777,6 +13180,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "license": "MIT",
@@ -14958,6 +15371,18 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.5.tgz",
+      "integrity": "sha512-Q76E3lnIV+4YT9AHcrHEHYmAd9LKwUAbPXDm7FlqVGDHiSOhX3RDjT8dm0AxbJup6WgOb1YEcKyCr11kBJR5KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@nivo/core": "^0.99.0",
+    "@nivo/pie": "^0.99.0",
     "@supabase/supabase-js": "^2.53.0",
     "dayjs": "^1.11.13",
     "framer-motion": "^12.23.12",

--- a/src/components/sleep/SleepAnimatedSwitch.jsx
+++ b/src/components/sleep/SleepAnimatedSwitch.jsx
@@ -1,11 +1,13 @@
 import { AnimatePresence, motion } from "framer-motion";
 import SleepStats from "./SleepStats";
+import SleepRecord from "./SleepRecord";
+import SleepQualityRating from "./SleepQualityRating";
 
-function SleepAnimatedSwitch({ activeTab }) {
+function SleepAnimatedSwitch({ activeTab, setActiveTab, rating, setRating }) {
   return (
     <div className="sleep-animated-switch">
       <AnimatePresence mode="wait">
-        {activeTab === "record" ? (
+        {activeTab === "record" && (
           <motion.div
             key="record"
             initial={{ opacity: 0, x: -20 }}
@@ -13,9 +15,16 @@ function SleepAnimatedSwitch({ activeTab }) {
             exit={{ opacity: 0, x: 20 }}
             transition={{ duration: 0.3 }}
           >
-            {/* <SleepRecord /> */}
+            <SleepRecord />
+            <SleepQualityRating
+              rating={rating}
+              setRating={setRating}
+              onSaveComplete={() => setActiveTab("stats")}
+            />
           </motion.div>
-        ) : (
+        )}
+
+        {activeTab === "stats" && (
           <motion.div
             key="stats"
             initial={{ opacity: 0, x: 20 }}

--- a/src/components/sleep/SleepQualityRating.jsx
+++ b/src/components/sleep/SleepQualityRating.jsx
@@ -1,8 +1,100 @@
-function SleepQualityRating() {
+import { FaStar } from "react-icons/fa6";
+import "../../css/sleep/sleepqualityrating.css";
+import { useState } from "react";
+import PostButton from "../common/PostButton";
+import TextArea from "../common/TextArea";
+
+function SleepQualityRating({ rating, setRating, onSaveComplete }) {
+  const [text, setText] = useState("");
+  const [error, setError] = useState("");
+  const [bedTime, setBedTime] = useState("");
+  const [wakeTime, setWakeTime] = useState("");
+
+  // 수면 메모 + 평가 저장 핸들러
+  const handlePost = () => {
+    setError("");
+
+    if (!bedTime || !wakeTime) {
+      setError("취침시간, 기상시간을 모두 설정해주세요");
+      return;
+    }
+
+    if (!rating) {
+      setError("수면 질 평가 별점을 설정해주세요");
+      return;
+    }
+
+    // 입력 유효성 검사
+    if (!text.trim()) {
+      setError("수면메모를 작성해주세요");
+      return;
+    }
+
+    // 저장할 객체 구조 정의
+    const savedData = {
+      day: new Date().toLocaleDateString("sv-SE"), // 'YYYY-MM-DD'
+      rating, // 수면 질 평가 값
+      text, // 수면 메모
+    };
+
+    // 로컬스토리지에 저장 (기존 항목에 추가)
+    const existing = JSON.parse(localStorage.getItem("sleepData")) || [];
+    const updated = [...existing, savedData];
+    localStorage.setItem("sleepData", JSON.stringify(updated));
+
+    alert("저장되었습니다");
+
+    // 저장 후 콜백 실행 (예: 통계 탭으로 전환)
+    if (onSaveComplete) {
+      onSaveComplete();
+    }
+  };
+
+  // 수면 질 평가 옵션 목록
+  const ratingOptions = [
+    { value: 1, label: "매우 나쁨" },
+    { value: 2, label: "나쁨" },
+    { value: 3, label: "보통" },
+    { value: 4, label: "좋음" },
+    { value: 5, label: "매우 좋음" },
+  ];
+
   return (
-    <div>
-      <h1>수면 평가 별점</h1>
-      SleepQualityRating
+    <div className="sleep-quality-rating">
+      <p className="sleep-quality-label">수면 질 평가</p>
+      <div className="rating-boxes">
+        {ratingOptions.map(option => (
+          <div
+            key={option.value}
+            className={`rating-box ${rating === option.value ? "active" : ""}`}
+            onClick={() =>
+              setRating(rating === option.value ? 0 : option.value)
+            }
+          >
+            <div className="stars">
+              {[...Array(option.value)].map((_, i) => (
+                <FaStar key={i} className="star filled" />
+              ))}
+            </div>
+            <p className="rating-label">{option.label}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="diary-section">
+        <TextArea
+          value={text}
+          onChange={e => {
+            setText(e.target.value);
+            if (error) setError("");
+          }}
+          placeholder="수면 중 특별한 점이나 느낌을 기록해보세요! (예: 꿈, 중간에 깬 시간 등)"
+          maxLength={1000}
+          error={error}
+        />
+      </div>
+
+      <PostButton onClick={handlePost}>저장하기</PostButton>
     </div>
   );
 }

--- a/src/components/sleep/SleepRecord.jsx
+++ b/src/components/sleep/SleepRecord.jsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import { FaStar } from "react-icons/fa6";
 import "../../css/sleep/sleeprecord.css";
 
 const SleepRecord = () => {
   const [bedTime, setBedTime] = useState("");
   const [wakeTime, setWakeTime] = useState("");
+  const [rating, setRating] = useState(0);
 
   return (
     <div className="sleep-record-container">
@@ -34,9 +34,6 @@ const SleepRecord = () => {
               onChange={e => setWakeTime(e.target.value)}
             />
           </div>
-        </div>
-        <div>
-          별<FaStar />
         </div>
       </div>
     </div>

--- a/src/components/sleep/SleepStats.jsx
+++ b/src/components/sleep/SleepStats.jsx
@@ -1,8 +1,86 @@
+import { useEffect, useState } from "react";
+import { ResponsivePie } from "@nivo/pie";
+import { FaStar } from "react-icons/fa6";
+import "../../css/sleep/sleepstats.css";
+
+const LABELS = ["매우 나쁨", "나쁨", "보통", "좋음", "매우 좋음"];
+const COLORS = ["#ff6961", "#fca652", "#f6d55c", "#88cc88", "#4caf50"];
+
 function SleepStats() {
+  const [records, setRecords] = useState([]);
+
+  useEffect(() => {
+    const saved = JSON.parse(localStorage.getItem("sleepData")) || [];
+    setRecords(saved);
+  }, []);
+
+  const chartData = LABELS.map((label, idx) => {
+    const value = records.filter(r => r.rating === idx + 1).length;
+    return { id: label, label, value };
+  }).filter(d => d.value > 0);
+
   return (
-    <div>
-      <h1>통계 및 히스토리 화면</h1>
-      SleepStats
+    <div className="sleep-stats-container">
+      <h2 className="stats-title">수면 통계</h2>
+
+      <div className="chart-wrapper">
+        {chartData.length > 0 ? (
+          <ResponsivePie
+            data={chartData}
+            margin={{ top: 40, right: 80, bottom: 80, left: 80 }}
+            innerRadius={0.5}
+            padAngle={0.7}
+            cornerRadius={3}
+            activeOuterRadiusOffset={8}
+            borderWidth={1}
+            borderColor={{ from: "color", modifiers: [["darker", 0.2]] }}
+            arcLinkLabelsSkipAngle={10}
+            arcLinkLabelsTextColor="#333333"
+            arcLabelsSkipAngle={10}
+            arcLabelsTextColor={{ from: "color", modifiers: [["darker", 2]] }}
+            colors={COLORS}
+            legends={[
+              {
+                anchor: "bottom",
+                direction: "row",
+                translateY: 50,
+                itemsSpacing: 5,
+                itemWidth: 80,
+                itemHeight: 18,
+                symbolSize: 12,
+                symbolShape: "circle",
+              },
+            ]}
+          />
+        ) : (
+          <p className="empty-chart">저장된 수면 기록이 없습니다.</p>
+        )}
+      </div>
+
+      <h3 className="history-title">수면 기록 히스토리</h3>
+      <div className="history-list">
+        {records.length ? (
+          records.map((e, i) => (
+            <div key={i} className="history-card">
+              <p>
+                <strong>{e.day}</strong>
+              </p>
+              <p>
+                {Array.from({ length: e.rating }, (_, j) => (
+                  <FaStar key={j} className="star-icon" />
+                ))}
+                <span className="rating-label"> {LABELS[e.rating - 1]}</span>
+              </p>
+              <p>
+                {e.bedTime} → {e.wakeTime}
+              </p>
+              <p>{e.text}</p>
+            </div>
+          ))
+        ) : (
+          <p className="empty-message">히스토리 없음</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/sleep/SleepTabBar.jsx
+++ b/src/components/sleep/SleepTabBar.jsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import "../../css/sleep/sleeptabbar.css";
 
 function SleepTabBar({ activeTab, setActiveTab }) {

--- a/src/css/sleep/sleepqualityrating.css
+++ b/src/css/sleep/sleepqualityrating.css
@@ -1,0 +1,55 @@
+.sleep-quality-rating {
+  margin-top: 24px;
+}
+
+.sleep-quality-label {
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.rating-boxes {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.rating-box {
+  flex: 1;
+  min-width: 80px;
+  padding: 35px;
+  border-radius: 12px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background: var(--color-primary-p-100, #fcf3fb);
+}
+
+.rating-box:hover {
+  box-shadow: 6px 6px 8px rgba(0, 0, 0, 0.15);
+  background-color: #fad4e8;
+}
+
+.rating-box.active {
+  border-color: gold;
+  background-color: #fff8dc;
+  box-shadow: 0 0 8px rgba(255, 215, 0, 0.6);
+}
+
+.stars {
+  font-size: 12px;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 6px;
+  filter: drop-shadow(1px 1px 2px rgba(0, 0, 0, 0.15));
+}
+
+.star.filled {
+  color: gold;
+}
+
+.rating-label {
+  font-size: 12px;
+  color: #555;
+  margin-bottom: 0px;
+}

--- a/src/css/sleep/sleeprecord.css
+++ b/src/css/sleep/sleeprecord.css
@@ -1,5 +1,5 @@
 .sleep-record-container {
-  background: white;
+  background: var(--color-primary-p-100, #fcf3fb);
   padding: 2rem;
   border-radius: 1rem;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);

--- a/src/css/sleep/sleepstats.css
+++ b/src/css/sleep/sleepstats.css
@@ -1,0 +1,40 @@
+.sleep-stats-container {
+  padding: 20px;
+  text-align: center;
+}
+
+.stats-title {
+  font-size: 24px;
+  margin-bottom: 10px;
+}
+
+.chart-section {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 30px;
+}
+
+.history-title {
+  font-size: 20px;
+  margin-bottom: 10px;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.history-card {
+  border: 1px solid #ccc;
+  border-radius: 12px;
+  padding: 12px;
+  background-color: #f9f9f9;
+  text-align: left;
+}
+
+.empty-message {
+  color: #999;
+}

--- a/src/pages/SleepRecordPage.jsx
+++ b/src/pages/SleepRecordPage.jsx
@@ -1,22 +1,29 @@
 import { useState } from "react";
 import BackButton from "../components/common/BackButton";
 import Container from "../components/common/Container";
-import SleepRecord from "../components/sleep/SleepRecord";
 import SleepTabBar from "../components/sleep/SleepTabBar";
-import "../css/sleep/sleeprecordpage.css";
 import SleepAnimatedSwitch from "../components/sleep/SleepAnimatedSwitch";
+import "../css/sleep/sleeprecordpage.css";
 
-function SleepRecordPage({ activeTab, setActiveTab }) {
-  // const [activeTab, setActiveTab] = useState("record");
+function SleepRecordPage() {
+  const [activeTab, setActiveTab] = useState("record");
+  const [rating, setRating] = useState(0);
 
   return (
     <Container>
       <BackButton to="/" />
       <div className="sleep_record">
         <div className="sleep_record_wrap">
+          {/* 상단 탭 */}
           <SleepTabBar activeTab={activeTab} setActiveTab={setActiveTab} />
-          <SleepAnimatedSwitch activeTab={activeTab} />
-          <SleepRecord />
+
+          {/* 탭 내용 */}
+          <SleepAnimatedSwitch
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+            rating={rating}
+            setRating={setRating}
+          />
         </div>
       </div>
     </Container>


### PR DESCRIPTION
## 작업 내용 요약

- 수면 기록 탭 (`record`)
  - 수면 질 평가 기능 구현 (1~5점 별점 + 라벨)
  - 수면 메모 기능 추가 (텍스트 입력 가능)
  - 평가 및 메모 저장 기능 구현 (localStorage 사용)
  - 평가 값 클릭 두 번 시 초기화 처리

- 통계 및 히스토리 탭 (`stats`)
  - 저장된 수면 데이터 기반 통계 UI 구현 (nivo pie chart)
  - 수면 데이터 리스트(히스토리) 조회 가능

- UI 구성
  - 상단 탭바 구현 (`SleepTabBar`)
  - Framer Motion을 활용한 탭 간 전환 애니메이션
  - 탭에 따라 작성 컴포넌트 (`SleepQualityRating`)가 조건부 렌더링되도록 처리
---
## 기타 사항

- 저장된 데이터는 로컬스토리지(`localStorage`) 기준으로 처리됨
- `recharts` → `@nivo/pie`로 변경하여 시각화 라이브러리 확정
- `react-icons/fa6`를 사용하여 별점 아이콘 적용
---
## 체크리스트 (이거 체크해봤어요)

- 기능별로 분리된 컴포넌트 구조
- 탭 전환 애니메이션 정상 동작
- 데이터 저장 및 불러오기 정상 작동
- 수면 질 평가, 메모, 저장 기능 UX 완성
---
## 미반영

- pie 차트 미반영, 로컬스토리지 저장 미구현 등.. 지금 너무 졸려서 내일..다시 작업하겠습니다
