### PR TITLE
[feat] 최근 7일 수면 파이차트 및 주간 통계 기능 구현

### DIFF
--- a/src/components/sleep/PieChartAndLabels.jsx
+++ b/src/components/sleep/PieChartAndLabels.jsx
@@ -1,0 +1,71 @@
+import { ResponsivePie } from "@nivo/pie";
+import { FaStar } from "react-icons/fa6";
+
+const LABELS = ["매우 나쁨", "나쁨", "보통", "좋음", "매우 좋음"];
+const COLORS = ["#ff6961", "#fca652", "#f6d55c", "#88cc88", "#8FC8F6"];
+
+function PieChartAndLabels({ records }) {
+  // ㅊㅏ트 7일 이내의 데이터만 반영
+  const now = new Date();
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(now.getDate() - 6);
+
+  const recentRecords = records.filter(r => {
+    const recordDate = new Date(r.day);
+    return recordDate >= sevenDaysAgo && recordDate <= now;
+  });
+
+  const chartData = LABELS.map((label, idx) => {
+    const value = recentRecords.filter(r => r.rating === idx + 1).length;
+    return { id: label, label, value };
+  }).filter(d => d.value > 0);
+
+  if (chartData.length === 0) {
+    return <p className="empty-chart">저장된 수면 기록이 없습니다.</p>;
+  }
+
+  return (
+    <div className="chart-section">
+      <div className="pie-chart-wrapper">
+        <ResponsivePie
+          data={chartData}
+          margin={{ top: 40, right: 80, bottom: 80, left: 80 }}
+          innerRadius={0.5}
+          padAngle={0.7}
+          cornerRadius={3}
+          activeOuterRadiusOffset={8}
+          borderWidth={1}
+          borderColor={{ from: "color", modifiers: [["darker", 0.2]] }}
+          arcLinkLabelsSkipAngle={10}
+          arcLinkLabelsTextColor="#333333"
+          arcLabelsSkipAngle={10}
+          arcLabelsTextColor={{ from: "color", modifiers: [["darker", 2]] }}
+          colors={COLORS}
+          legends={[]} // 범례는 생략
+        />
+      </div>
+
+      <div className="labels-right">
+        {LABELS.map((label, idx) => {
+          const starCount = 5 - idx;
+          return (
+            <div className="label-item" key={idx}>
+              <div
+                className="color-circle"
+                style={{ backgroundColor: COLORS[idx] }}
+              />
+              <span>{label}</span>
+              <div className="stars">
+                {Array.from({ length: starCount }).map((_, i) => (
+                  <FaStar key={i} />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default PieChartAndLabels;

--- a/src/components/sleep/SleepEntryCard.jsx
+++ b/src/components/sleep/SleepEntryCard.jsx
@@ -1,24 +1,65 @@
+// src/components/sleep/SleepEntryCard.jsx
+import "../../css/sleep/sleepentrycard.css";
 import { FaStar } from "react-icons/fa6";
-import "../../css/sleep/sleepstats.css";
-
-const LABELS = ["매우 나쁨", "나쁨", "보통", "좋음", "매우 좋음"];
 
 function SleepEntryCard({ entry }) {
+  const { day, rating, text, bedTime, wakeTime } = entry;
+
+  const totalSleep = (() => {
+    const [bedH, bedM] = bedTime.split(":").map(Number);
+    const [wakeH, wakeM] = wakeTime.split(":").map(Number);
+
+    let start = bedH * 60 + bedM;
+    let end = wakeH * 60 + wakeM;
+
+    if (end <= start) end += 24 * 60;
+
+    const diff = end - start;
+    const hours = Math.floor(diff / 60);
+    const mins = diff % 60;
+
+    return `${hours}시간 ${mins}분`;
+  })();
+
+  const formattedDate = new Date(day).toLocaleDateString("ko-KR", {
+    month: "long",
+    day: "numeric",
+  });
+
   return (
-    <div className="history-card">
-      <p>
-        <strong>{entry.day}</strong>
-      </p>
-      <p>
-        {Array.from({ length: entry.rating }, (_, j) => (
-          <FaStar key={j} className="star-icon" />
-        ))}
-        <span className="rating-label"> {LABELS[entry.rating - 1]}</span>
-      </p>
-      <p>
-        {entry.bedTime} → {entry.wakeTime}
-      </p>
-      <p>{entry.text}</p>
+    <div className="sleep-entry-card">
+      <div className="sleep-entry-header">
+        <span>{formattedDate}</span>
+        <div className="sleep-entry-stars">
+          {Array.from({ length: rating }).map((_, i) => (
+            <FaStar key={i} />
+          ))}
+        </div>
+      </div>
+
+      <div className="sleep-entry-info">
+        <div>
+          <strong>취침</strong>
+          <span>{bedTime}</span>
+        </div>
+        <div>
+          <strong>기상</strong>
+          <span>{wakeTime}</span>
+        </div>
+        <div>
+          <strong>총 수면</strong>
+          <span>{totalSleep}</span>
+        </div>
+        <div>
+          <strong>수면 질</strong>
+          <span>{rating}/5</span>
+        </div>
+      </div>
+
+      <div className="sleep-entry-memo">
+        <div className="sleep-memo-title">메모</div>
+        <div className="sleep-memo">{text}</div>
+      </div>
     </div>
   );
 }

--- a/src/components/sleep/SleepStats.jsx
+++ b/src/components/sleep/SleepStats.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import { ResponsivePie } from "@nivo/pie";
-import { FaStar } from "react-icons/fa6";
-import SleepEntryCard from "./SleepEntryCard";
 import "../../css/sleep/sleepstats.css";
+import PieChartWithLabels from "./PieChartAndLabels";
+import SleepEntryCard from "./SleepEntryCard";
+import SleepWeeklySummary from "./SleepWeeklySummary";
 
 const mockData = [
   {
@@ -64,9 +64,13 @@ const mockData = [
 ];
 
 const LABELS = ["매우 나쁨", "나쁨", "보통", "좋음", "매우 좋음"];
-const COLORS = ["#ff6961", "#fca652", "#f6d55c", "#88cc88", "#4caf50"];
+const COLORS = ["#ff6961", "#fca652", "#f6d55c", "#88cc88", "#8FC8F6"];
 
 function SleepStats() {
+  useEffect(() => {
+    setRecords(mockData);
+  }, []);
+
   const [records, setRecords] = useState([]);
 
   localStorage.setItem("sleepData", JSON.stringify(mockData));
@@ -86,41 +90,10 @@ function SleepStats() {
     <div className="sleep-stats-container">
       <h2 className="stats-title">수면 통계</h2>
 
-      <div className="chart-wrapper">
-        {chartData.length > 0 ? (
-          <ResponsivePie
-            data={chartData}
-            margin={{ top: 40, right: 80, bottom: 80, left: 80 }}
-            innerRadius={0.5}
-            padAngle={0.7}
-            cornerRadius={3}
-            activeOuterRadiusOffset={8}
-            borderWidth={1}
-            borderColor={{ from: "color", modifiers: [["darker", 0.2]] }}
-            arcLinkLabelsSkipAngle={10}
-            arcLinkLabelsTextColor="#333333"
-            arcLabelsSkipAngle={10}
-            arcLabelsTextColor={{ from: "color", modifiers: [["darker", 2]] }}
-            colors={COLORS}
-            legends={[
-              {
-                anchor: "bottom",
-                direction: "row",
-                translateY: 50,
-                itemsSpacing: 5,
-                itemWidth: 80,
-                itemHeight: 18,
-                symbolSize: 12,
-                symbolShape: "circle",
-              },
-            ]}
-          />
-        ) : (
-          <p className="empty-chart">저장된 수면 기록이 없습니다.</p>
-        )}
-      </div>
-
-      <h3 className="history-title">수면 기록 히스토리</h3>
+      <PieChartWithLabels records={records} />
+      <h1>주간 수면 통계</h1>
+      <SleepWeeklySummary records={records} />
+      <h1 className="history-title">수면 기록 히스토리</h1>
       <div className="history-list">
         {records.length ? (
           records.map((entry, i) => <SleepEntryCard key={i} entry={entry} />)

--- a/src/components/sleep/SleepWeeklySummary.jsx
+++ b/src/components/sleep/SleepWeeklySummary.jsx
@@ -1,0 +1,58 @@
+import "../../css/sleep/sleepweeklysummary.css";
+
+function SleepWeeklySummary({ records = [] }) {
+  const now = new Date();
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(now.getDate() - 6);
+
+  const recentRecords = records.filter(r => {
+    const date = new Date(r.day);
+    return date >= sevenDaysAgo && date <= now;
+  });
+
+  const averageRating =
+    recentRecords.reduce((sum, r) => sum + r.rating, 0) /
+    (recentRecords.length || 1);
+
+  const averageSleepMinutes =
+    recentRecords.reduce((sum, r) => {
+      const [bedH, bedM] = r.bedTime.split(":").map(Number);
+      const [wakeH, wakeM] = r.wakeTime.split(":").map(Number);
+      let start = bedH * 60 + bedM;
+      let end = wakeH * 60 + wakeM;
+      if (end <= start) end += 24 * 60;
+      return sum + (end - start);
+    }, 0) / (recentRecords.length || 1);
+
+  const avgHours = Math.floor(averageSleepMinutes / 60);
+  const avgMins = Math.round(averageSleepMinutes % 60);
+
+  const averageEfficiency = "85%"; // 추후 개선 가능
+
+  return (
+    <div className="weekly-summary">
+      {recentRecords.length === 0 ? (
+        <p>최근 7일 간의 기록이 없습니다.</p>
+      ) : (
+        <div className="summary-grid">
+          <div className="stat-card">
+            <div className="stat-value">
+              {avgHours}시간 {avgMins}분
+            </div>
+            <div className="stat-label">평균 수면 시간</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-value">{averageRating.toFixed(1)} / 5</div>
+            <div className="stat-label">평균 수면 질</div>
+          </div>
+          <div className="stat-card">
+            <div className="stat-value">{averageEfficiency}</div>
+            <div className="stat-label">평균 수면 효율</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SleepWeeklySummary;

--- a/src/css/home/homepage.css
+++ b/src/css/home/homepage.css
@@ -1,8 +1,6 @@
 /* 메인 페이지 */
 .mainpage {
   font-family: "tj400";
-  /* max-width: 300%;
-  max-height: 300%; */
 }
 .mainpage_wrap {
   color: #3a3a74;

--- a/src/css/home/statssection.css
+++ b/src/css/home/statssection.css
@@ -2,7 +2,6 @@
   padding: 20px 0;
 }
 .total {
-  cursor: pointer;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;

--- a/src/css/sleep/sleepentrycard.css
+++ b/src/css/sleep/sleepentrycard.css
@@ -1,6 +1,70 @@
-.chart-section {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 30px;
+.sleep-entry-card {
+  background: var(--color-primary-p-100, #fcf3fb);
+  border-radius: 16px;
+  padding: 16px 24px;
+  margin-bottom: 20px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
 }
 
+.sleep-entry-header {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  font-weight: bold;
+  font-size: 16px;
+  margin-bottom: 15px;
+}
+
+.sleep-entry-stars {
+  display: flex;
+  color: gold;
+  font-size: 15px;
+}
+
+.sleep-entry-info {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  color: #333;
+  margin-bottom: 12px;
+}
+
+.sleep-entry-info div {
+  text-align: center;
+  flex: 1;
+}
+.sleep-entry-card div strong {
+  color: var(--color-secondary-s-100, #544783);
+}
+
+.sleep-entry-info div span {
+  display: block;
+  margin-top: 4px;
+  font-weight: bold;
+  font-size: 16px;
+  color: var(--color-secondary-s-200, #493d78);
+}
+
+.sleep-entry-memo {
+  background-color: white;
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 14px;
+  color: #444;
+  display: flex;
+  flex-direction: column;
+}
+
+.sleep-memo-title {
+  padding-bottom: 3px;
+  display: flex;
+  flex-direction: flex-start;
+  color: var(--color-secondary-s-100, #544783);
+}
+.sleep-memo {
+  display: flex;
+  flex-direction: flex-start;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/css/sleep/sleepstats.css
+++ b/src/css/sleep/sleepstats.css
@@ -8,40 +8,82 @@
   margin-bottom: 10px;
 }
 
-.chart-wrapper {
-  height: 300px;
+.chart-section {
   width: 100%;
-  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   margin-bottom: 30px;
+  gap: 10px;
 }
 
-.history-title {
-  font-size: 20px;
-  margin-bottom: 10px;
+.pie-chart-wrapper {
+  flex: 1;
+  height: 300px;
+  min-width: 300px;
+  max-width: 500px;
+  position: relative;
 }
 
-.history-list {
+.pie-chart-left {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+.labels-right {
   display: flex;
   flex-direction: column;
-  gap: 15px;
-  max-height: 300px;
-  overflow-y: auto;
+  align-items: flex-start;
+  gap: 12px;
 }
 
-.history-card {
-  border: 1px solid #ccc;
-  border-radius: 12px;
-  padding: 12px;
-  background-color: #f9f9f9;
-  text-align: left;
+.label-item {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 500;
+  gap: 10px;
+}
+.label-item svg {
+  gap: 10px;
+  filter: drop-shadow(1px 1px 1px rgba(0, 0, 0, 0.2));
+}
+.label-item span {
+  min-width: 70px;
 }
 
-.empty-message {
-  color: #999;
+.rating-label-list {
+  display: flex;
+  flex-direction: column-reverse; /* 매우 좋음이 위로 */
+  justify-content: center;
+  align-items: flex-start;
+  gap: 10px;
 }
 
-/* 별 모양 아이콘 */
+.rating-label-item {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 500;
+  gap: 8px;
+}
+
+/* 원 색상 */
+.color-circle {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+/* 별 아이콘 */
 .star-icon {
   color: #ffd700;
-  margin-right: 2px;
+}
+
+/* 별 아이콘 */
+.label-item svg {
+  color: #ffd700;
+  margin-left: 6px;
 }

--- a/src/css/sleep/sleepweeklysummary.css
+++ b/src/css/sleep/sleepweeklysummary.css
@@ -1,0 +1,32 @@
+.weekly-summary {
+  padding: 16px;
+  background: var(--color-primary-p-100, #fcf3fb);
+  border-radius: 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  text-align: center;
+}
+
+.stat-card {
+  background-color: white;
+  padding: 30px;
+  border-radius: 16px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.stat-value {
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 4px;
+  color: #333;
+}
+
+.stat-label {
+  font-size: 14px;
+  color: #777;
+}


### PR DESCRIPTION
### 주요 변경 사항
- 최근 7일 데이터를 기반으로 수면 질 분포를 나타내는 파이차트 구현
- 주간 수면 통계 카드 UI (`평균 수면 시간`, `평균 수면 질`, `평균 수면 효율`) 추가
- Mock 데이터를 기반으로 자동 필터링 되도록 처리
- 반응형 3열 레이아웃 및 CSS 적용

### 테스트 사항
- Mock 데이터 기반으로 정상 렌더링 확인
- 기록이 없는 경우 안내 문구 노출 확인
- PieChart와 통계 모두 최근 7일만 반영됨

### 기타
- 수면 효율은 임시로 `85%`로 고정 (추후 계산 방식 적용 예정)
